### PR TITLE
Make :mod:`PySide2` not fail

### DIFF
--- a/sphinx_qt_documentation/__init__.py
+++ b/sphinx_qt_documentation/__init__.py
@@ -91,8 +91,8 @@ def missing_reference(
             return None
         objtypes = ["%s:%s" % (domain, objtype) for objtype in objtypes]
     if target.startswith("PySide2"):
-        head, tail = target.split(".", 1)
-        target = "PyQt5." + tail
+        head, dot, tail = target.partition(".")
+        target = "PyQt5" + dot + tail
     if signal_pattern.match(target):
         uri = signal_slot_uri[app.config.qt_documentation]
         dispname = signal_name[app.config.qt_documentation]

--- a/tests/document01/index.rst
+++ b/tests/document01/index.rst
@@ -3,3 +3,5 @@ Welcome to sphinx-qt-documentation-test01's documentation!
 
 Please show me some `QtGui` classes.
 
+One root module is :mod:`PyQt5`.
+Another is :mod:`PySide2`.


### PR DESCRIPTION
Fixes #13

Draft for:
- [ ] It doesn't fail now but I haven't verified an actual working link.