### PR TITLE
fix missing attribute `Signal.signatures`

### DIFF
--- a/sphinx_qt_documentation/_missing_reference.py
+++ b/sphinx_qt_documentation/_missing_reference.py
@@ -230,5 +230,5 @@ def autodoc_process_signature(
             return match[0], None
 
         pos = len(name.rsplit(".", 1)[1])
-        return ", ".join(sig[pos:] for sig in obj.signatures), None
+        return ", ".join(sig[pos:] for sig in getattr(obj, 'signatures', [])), None
     return None


### PR DESCRIPTION
not sure when this occurs, but I ran into an error when trying this extension:
```
Extension error (sphinx_qt_documentation):
Handler <function autodoc_process_signature at 0x11d04be50> for event 'autodoc-process-signature' threw an exception (exception: 'PySide2.QtCore.Signal' object has no attribute 'signatures')
make: *** [html] Error 2
```

this fixes it
